### PR TITLE
Remove last occurences of epsilon parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bezier
 [![Build Status](https://api.travis-ci.com/romb-technologies/Bezier.svg?branch=master)](https://api.travis-ci.com/romb-technologies/Bezier)
-![v0.3](https://img.shields.io/badge/version-0.3-blue.svg)
+![v0.3.1](https://img.shields.io/badge/version-0.3.1-blue.svg)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/47864506cafa49f2a3628638642dd4e8)](https://www.codacy.com/gh/romb-technologies/Bezier/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=romb-technologies/Bezier&amp;utm_campaign=Badge_Grade)
 
 Fast and lightweight class for using the Bezier curves of any order in C++

--- a/include/Bezier/bezier.h
+++ b/include/Bezier/bezier.h
@@ -255,10 +255,9 @@ public:
   /*!
    * \brief Get the points of intersection with another curve
    * \param curve Curve to intersect with
-   * \param epsilon Precision of resulting intersection
    * \return A vector af points of intersection between curves
    */
-  PointVector intersections(const Curve& curve, double epsilon = 0.001) const;
+  PointVector intersections(const Curve& curve) const;
 
   /*!
    * \brief Get the parameter t where curve is closest to given point

--- a/include/Bezier/bezier.h
+++ b/include/Bezier/bezier.h
@@ -111,10 +111,9 @@ public:
    * \brief Compute parameter t which is S distance from given t
    * \param t Curve parameter
    * \param s Distance to iterate
-   * \param epsilon Precision of resulting t
    * \return New parameter t
    */
-  double iterateByLength(double t, double s, double epsilon = 0.001) const;
+  double iterateByLength(double t, double s) const;
 
   /*!
    * \brief Reverse order of control points

--- a/include/Bezier/declarations.h
+++ b/include/Bezier/declarations.h
@@ -72,5 +72,10 @@ using Vector = Eigen::Vector2d;
  * \brief Bounding box class
  */
 using BoundingBox = Eigen::AlignedBox2d;
+
+/*!
+ * \brief Precision for numerical methods
+ */
+const double _epsilon = std::sqrt(std::numeric_limits<double>::epsilon());
 } // namespace Bezier
 #endif // DECLARATIONS_H

--- a/include/Bezier/polycurve.h
+++ b/include/Bezier/polycurve.h
@@ -150,10 +150,9 @@ public:
    * \brief Compute parameter t which is S distance from given t
    * \param t Curve parameter
    * \param s Distance to iterate
-   * \param epsilon Precision of resulting t
    * \return New parameter t
    */
-  double iterateByLength(double t, double s, double epsilon = 0.001) const;
+  double iterateByLength(double t, double s) const;
 
   /*!
    * \brief Get first and last control points

--- a/include/Bezier/polycurve.h
+++ b/include/Bezier/polycurve.h
@@ -241,11 +241,9 @@ public:
   /*!
    * \brief Get the points of intersection with another curve or polycurve
    * \param curve Curve to intersect with
-   * \param epsilon Precision of resulting intersection
    * \return A vector af points of intersection between curves
    */
-  template <typename Curve_PolyCurve>
-  PointVector intersections(const Curve_PolyCurve& curve, double epsilon = 0.001) const;
+  template <typename Curve_PolyCurve> PointVector intersections(const Curve_PolyCurve& curve) const;
 
   /*!
    * \brief Get the parameter t where polycurve is closest to given point

--- a/src/bezier.cpp
+++ b/src/bezier.cpp
@@ -8,6 +8,16 @@
 
 using namespace Bezier;
 
+#ifndef __cpp_lib_make_unique
+namespace std
+{
+template <typename T, typename... Args> inline std::unique_ptr<T> make_unique(Args&&... args)
+{
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+} // namespace std
+#endif
+
 Eigen::VectorXd trimZeroes(const Eigen::VectorXd& vec)
 {
   auto idx = vec.size();
@@ -442,7 +452,7 @@ PointVector Curve::intersections(const Curve& curve) const
 #if __cpp_init_captures
       std::for_each(t.begin() + k + 1, t.end(), [t = t[k]](double& x) { x = (x - t) / (1 - t); });
 #else
-      std::for_each(t.begin() + k + 1, t.end(), [t, k](double& x) { x = (x - t[k]) / (1 - t[k]); });
+      std::for_each(t.begin() + k + 1, t.end(), [&t, k](double& x) { x = (x - t[k]) / (1 - t[k]); });
 #endif
     }
 

--- a/src/polycurve.cpp
+++ b/src/polycurve.cpp
@@ -200,24 +200,24 @@ BoundingBox PolyCurve::boundingBox() const
 namespace Bezier
 {
 
-template <> PointVector PolyCurve::intersections<Curve>(const Curve& curve, double epsilon) const
+template <> PointVector PolyCurve::intersections<Curve>(const Curve& curve) const
 {
   PointVector points;
   for (const auto& curve2 : curves_)
   {
-    auto new_points = curve2.intersections(curve, epsilon);
+    auto new_points = curve2.intersections(curve);
     points.reserve(points.size() + new_points.size());
     points.insert(points.end(), std::make_move_iterator(new_points.begin()), std::make_move_iterator(new_points.end()));
   }
   return points;
 }
 
-template <> PointVector PolyCurve::intersections<PolyCurve>(const PolyCurve& poly_curve, double epsilon) const
+template <> PointVector PolyCurve::intersections<PolyCurve>(const PolyCurve& poly_curve) const
 {
   PointVector points;
   for (const auto& curve : curves_)
   {
-    auto new_points = poly_curve.intersections(curve, epsilon);
+    auto new_points = poly_curve.intersections(curve);
     points.reserve(points.size() + new_points.size());
     points.insert(points.end(), std::make_move_iterator(new_points.begin()), std::make_move_iterator(new_points.end()));
   }

--- a/src/polycurve.cpp
+++ b/src/polycurve.cpp
@@ -73,8 +73,10 @@ double PolyCurve::length(double t1, double t2) const
                                 [](double sum, const Curve& curve) { return sum + curve.length(); });
 }
 
-double PolyCurve::iterateByLength(double t, double s, double epsilon) const
+double PolyCurve::iterateByLength(double t, double s) const
 {
+  const double epsilon = std::sqrt(std::numeric_limits<double>::epsilon());
+
   if (std::fabs(s) < epsilon) // no-op
     return t;
 
@@ -104,7 +106,7 @@ double PolyCurve::iterateByLength(double t, double s, double epsilon) const
     t = 0.0;
   }
 
-  return idx + curves_[idx].iterateByLength(t, s, epsilon);
+  return idx + curves_[idx].iterateByLength(t, s);
 }
 
 std::pair<Point, Point> PolyCurve::endPoints() const

--- a/src/polycurve.cpp
+++ b/src/polycurve.cpp
@@ -75,17 +75,15 @@ double PolyCurve::length(double t1, double t2) const
 
 double PolyCurve::iterateByLength(double t, double s) const
 {
-  const double epsilon = std::sqrt(std::numeric_limits<double>::epsilon());
-
-  if (std::fabs(s) < epsilon) // no-op
+  if (std::fabs(s) < _epsilon) // no-op
     return t;
 
   double s_t = length(t);
 
-  if (s < -s_t + epsilon) // out-of-scope
+  if (s < -s_t + _epsilon) // out-of-scope
     return 0.0;
 
-  if (s > length() - s_t - epsilon) // out-of-scope
+  if (s > length() - s_t - _epsilon) // out-of-scope
     return size();
 
   unsigned idx = curveIdx(t);
@@ -93,13 +91,13 @@ double PolyCurve::iterateByLength(double t, double s) const
 
   s_t = s < 0 ? s_t - length(idx) : length(idx + 1) - s_t;
 
-  while (-s_t > s + epsilon)
+  while (-s_t > s + _epsilon)
   {
     s += s_t;
     s_t = curves_[--idx].length();
     t = 1.0;
   }
-  while (s_t < s - epsilon)
+  while (s_t < s - _epsilon)
   {
     s -= s_t;
     s_t = curves_[++idx].length();


### PR DESCRIPTION
- `epsilon` is now hardcoded at `sqrt(numerical_limits<double>::epsilon())`
- better initial bracketing for `iterateByLength`
- small code cleanup