### PR TITLE
Modernize cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_compile_options(-fPIC -O2)
-
 find_package(Eigen3 REQUIRED)
-include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR} include)
 
 set(Bezier_SRC
   ${PROJECT_SOURCE_DIR}/src/bezier.cpp
@@ -34,10 +31,14 @@ else()
   add_library(bezier STATIC ${Bezier_SRC})
 endif()
 
+
 target_include_directories(bezier PUBLIC
-  $<BUILD_INTERFACE:${Bezier_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
+
+target_link_libraries(bezier PUBLIC Eigen3::Eigen)
+set_property(TARGET bezier PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 set_target_properties(bezier PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(bezier PROPERTIES PUBLIC_HEADER "${Bezier_INC}")
@@ -47,3 +48,5 @@ install(TARGETS bezier
   EXPORT bezier-export DESTINATION "lib"
   PUBLIC_HEADER DESTINATION "include/Bezier")
 install(EXPORT bezier-export DESTINATION "lib/cmake/Bezier" FILE BezierConfig.cmake)
+
+add_library(bezier::bezier ALIAS bezier)


### PR DESCRIPTION
This PR moves to a more modern target based CMake usage. This avoids setting properties globally for potential consumers of this project.