### PR TITLE
v040 API change + new methods

### DIFF
--- a/include/Bezier/bezier.h
+++ b/include/Bezier/bezier.h
@@ -236,6 +236,13 @@ public:
   BoundingBox boundingBox() const;
 
   /*!
+   * \brief Split the curve into subcurves at multiple parameters
+   * \param t Vector of curve parameters at which to split the curve
+   * \return A vector of subcurves
+   */
+  std::vector<Curve> splitCurve(const ParamVector& t) const;
+
+  /*!
    * \brief Split the curve into two subcurves
    * \param t Curve parameter at which to split the curve
    * \return Pair of two subcurves

--- a/include/Bezier/bezier.h
+++ b/include/Bezier/bezier.h
@@ -110,10 +110,10 @@ public:
   /*!
    * \brief Compute parameter t which is S distance from given t
    * \param t Curve parameter
-   * \param s Distance to iterate
+   * \param ds Distance to iterate
    * \return New parameter t
    */
-  double iterateByLength(double t, double ds) const;
+  double step(double t, double ds) const;
 
   /*!
    * \brief Reverse order of control points
@@ -133,7 +133,7 @@ public:
    * Curve will always retain its shape
    * \warning Resets cached data
    */
-  void elevateOrder();
+  void raiseOrder();
 
   /*!
    * \brief Lower the curve order by 1

--- a/include/Bezier/bezier.h
+++ b/include/Bezier/bezier.h
@@ -128,16 +128,6 @@ public:
   void setControlPoint(unsigned idx, const Point& point);
 
   /*!
-   * \brief Manipulate the curve so that it passes through wanted point for given 't'
-   * \param t Curve parameter
-   * \param point Point where curve should pass for a given t
-   *
-   * \warning CAN THROW: Only works for quadratic and cubic curves
-   * \warning Resets cached data
-   */
-  void manipulateCurvature(double t, const Point& point);
-
-  /*!
    * \brief Raise the curve order by 1
    *
    * Curve will always retain its shape

--- a/include/Bezier/bezier.h
+++ b/include/Bezier/bezier.h
@@ -81,10 +81,31 @@ public:
 
   /*!
    * \brief Get a polyline representation of the curve as a vector of points on curve
+   * \return A vector of polyline vertices
+   * \note Default flatness parameter is calculated as 0.1% of bounding box diagonal
+   */
+  PointVector polyline() const;
+
+  /*!
+   * \brief Get a polyline representation of the curve as a vector of points on curve
    * \param flatness Error tolerance of approximation
    * \return A vector of polyline vertices
    */
-  PointVector polyline(double flatness = 0.5) const;
+  PointVector polyline(double flatness) const;
+
+  /*!
+   * \brief Get curve parameters corresponding to polyline points
+   * \return A vector of curve parameters for each polyline vertex
+   * \note Default flatness parameter is calculated as 0.1% of bounding box diagonal
+   */
+  ParamVector polylineParams() const;
+
+  /*!
+   * \brief Get curve parameters corresponding to polyline points
+   * \param flatness Error tolerance of approximation
+   * \return A vector of curve parameters for each polyline vertex
+   */
+  ParamVector polylineParams(double flatness) const;
 
   /*!
    * \brief Compute exact arc length using Chebyshev polynomials
@@ -289,6 +310,7 @@ private:
     std::optional<ParamVector> roots;                           /*! Roots stored for later use */
     std::optional<BoundingBox> bounding_box;                    /*! Bounding box stored for later use */
     std::optional<PointVector> polyline;                        /*! Polyline stored for later use */
+    std::optional<ParamVector> polyline_t;                      /*! Polyline t parameters stored for later use */
     double polyline_flatness{};                                 /*! Flatness value associated with stored polyline */
     std::optional<Eigen::VectorXd> projection_polynomial_const; /*! Constant part of point projection polynomial */
     std::optional<Eigen::MatrixX2d> projection_polynomial_der;  /*! Polynomial representation of curve derivative */

--- a/include/Bezier/bezier.h
+++ b/include/Bezier/bezier.h
@@ -261,7 +261,7 @@ public:
    * \param t Vector of curve parameters at which to split the curve
    * \return A vector of subcurves
    */
-  std::vector<Curve> splitCurve(const ParamVector& t) const;
+  std::vector<Curve> splitCurve(const ParamVector& t_vector) const;
 
   /*!
    * \brief Split the curve into two subcurves

--- a/include/Bezier/polycurve.h
+++ b/include/Bezier/polycurve.h
@@ -120,10 +120,31 @@ public:
 
   /*!
    * \brief Get a polyline representation of the polycurve as a vector of points on curve
+   * \return A vector of polyline vertices
+   * \note Default flatness parameter is calculated as 0.1% of smallest subcurve bounding box diagonal
+   */
+  PointVector polyline() const;
+
+  /*!
+   * \brief Get a polyline representation of the polycurve as a vector of points on curve
    * \param flatness Error tolerance of approximation
    * \return A vector of polyline vertices
    */
-  PointVector polyline(double flatness = 0.5) const;
+  PointVector polyline(double flatness) const;
+
+  /*!
+   * \brief Get curve parameters corresponding to polyline points
+   * \return A vector of curve parameters for each polyline vertex
+   * \note Default flatness parameter is calculated as 0.1% of smallest subcurve bounding box diagonal
+   */
+  ParamVector polylineParams() const;
+
+  /*!
+   * \brief Get curve parameters corresponding to polyline points
+   * \param flatness Error tolerance of approximation
+   * \return A vector of curve parameters for each polyline vertex
+   */
+  ParamVector polylineParams(double flatness) const;
 
   /*!
    * \brief Compute exact arc length using Chebyshev polynomials

--- a/include/Bezier/polycurve.h
+++ b/include/Bezier/polycurve.h
@@ -121,7 +121,7 @@ public:
   /*!
    * \brief Get a polyline representation of the polycurve as a vector of points on curve
    * \return A vector of polyline vertices
-   * \note Default flatness parameter is calculated as 0.1% of smallest subcurve bounding box diagonal
+   * \note Each subcurve uses its own auto-calculated flatness (0.1% of bounding box diagonal)
    */
   PointVector polyline() const;
 
@@ -135,7 +135,7 @@ public:
   /*!
    * \brief Get curve parameters corresponding to polyline points
    * \return A vector of curve parameters for each polyline vertex
-   * \note Default flatness parameter is calculated as 0.1% of smallest subcurve bounding box diagonal
+   * \note Each subcurve uses its own auto-calculated flatness (0.1% of bounding box diagonal)
    */
   ParamVector polylineParams() const;
 

--- a/include/Bezier/polycurve.h
+++ b/include/Bezier/polycurve.h
@@ -149,10 +149,10 @@ public:
   /*!
    * \brief Compute parameter t which is S distance from given t
    * \param t Curve parameter
-   * \param s Distance to iterate
+   * \param ds Distance to iterate
    * \return New parameter t
    */
-  double iterateByLength(double t, double s) const;
+  double step(double t, double ds) const;
 
   /*!
    * \brief Get first and last control points

--- a/src/bezier.cpp
+++ b/src/bezier.cpp
@@ -334,18 +334,18 @@ BoundingBox Curve::boundingBox() const
   return *cache.bounding_box;
 }
 
-std::vector<Curve> Curve::splitCurve(const ParamVector& t) const
+std::vector<Curve> Curve::splitCurve(const ParamVector& t_vector) const
 {
-  auto sorted_t = t;
-  std::sort(sorted_t.begin(), sorted_t.end());
+  auto t_sorted = t_vector;
+  std::sort(t_sorted.begin(), t_sorted.end());
   std::vector<Curve> subcurves;
-  subcurves.reserve(sorted_t.size() + 1);
+  subcurves.reserve(t_sorted.size() + 1);
   auto leftover_cp = control_points_;
-  for (unsigned k{}; k < sorted_t.size(); k++)
+  for (unsigned k{}; k < t_sorted.size(); k++)
   {
-    subcurves.emplace_back(bc::leftSplit(N_, sorted_t[k]) * leftover_cp);
-    leftover_cp = bc::rightSplit(N_, sorted_t[k]) * leftover_cp;
-    std::for_each(sorted_t.begin() + k + 1, sorted_t.end(), [t = sorted_t[k]](double& x) { x = (x - t) / (1 - t); });
+    subcurves.emplace_back(bc::leftSplit(N_, t_sorted[k]) * leftover_cp);
+    leftover_cp = bc::rightSplit(N_, t_sorted[k]) * leftover_cp;
+    std::for_each(t_sorted.begin() + k + 1, t_sorted.end(), [t = t_sorted[k]](double& x) { x = (x - t) / (1 - t); });
   }
   subcurves.emplace_back(std::move(leftover_cp));
   return subcurves;
@@ -502,4 +502,3 @@ void Curve::Cache::clear()
   chebyshev_polynomial.reset();
   polyline_flatness = 0.0;
 }
-

--- a/src/bezier.cpp
+++ b/src/bezier.cpp
@@ -144,7 +144,7 @@ double Curve::length(double t) const
 
 double Curve::length(double t1, double t2) const { return length(t2) - length(t1); }
 
-double Curve::iterateByLength(double t, double ds) const
+double Curve::step(double t, double ds) const
 {
   if (std::fabs(ds) < bu::epsilon) // no-op
     return t;
@@ -206,7 +206,7 @@ void Curve::setControlPoint(unsigned idx, const Point& point)
   cache.clear();
 }
 
-void Curve::elevateOrder()
+void Curve::raiseOrder()
 {
   control_points_ = bc::raiseOrder(N_++) * control_points_;
   cache.clear();

--- a/src/bezier.cpp
+++ b/src/bezier.cpp
@@ -206,38 +206,6 @@ void Curve::setControlPoint(unsigned idx, const Point& point)
   cache.clear();
 }
 
-void Curve::manipulateCurvature(double t, const Point& point)
-{
-  if (N_ < 3 || N_ > 4)
-    throw std::logic_error{"Only quadratic and cubic curves can be manipulated"};
-
-  double r =
-      std::fabs((bu::pow(t, N_ - 1) + bu::pow(1 - t, N_ - 1) - 1) / (bu::pow(t, N_ - 1) + bu::pow(1 - t, N_ - 1)));
-  double u = bu::pow(1 - t, N_ - 1) / (bu::pow(t, N_ - 1) + bu::pow(1 - t, N_ - 1));
-  Point C = u * control_points_.row(0) + (1 - u) * control_points_.row(N_ - 1);
-  const Point& B = point;
-  Point A = B - (C - B) / r;
-
-  switch (N_)
-  {
-  case 3:
-    control_points_.row(1) = A;
-    break;
-  case 4:
-    Point e1 = control_points_.row(0) * bu::pow(1 - t, 2) + control_points_.row(1) * 2 * t * (1 - t) +
-               control_points_.row(2) * bu::pow(t, 2);
-    Point e2 = control_points_.row(1) * bu::pow(1 - t, 2) + control_points_.row(2) * 2 * t * (1 - t) +
-               control_points_.row(3) * bu::pow(t, 2);
-    e1 = B + e1 - valueAt(t);
-    e2 = B + e2 - valueAt(t);
-    Point v1 = A - (A - e1) / (1 - t);
-    Point v2 = A + (e2 - A) / t;
-    control_points_.row(1).noalias() = control_points_.row(0) + (v1.transpose() - control_points_.row(0)) / t;
-    control_points_.row(2).noalias() = control_points_.row(3) - (control_points_.row(3) - v2.transpose()) / (1 - t);
-  }
-  cache.clear();
-}
-
 void Curve::elevateOrder()
 {
   control_points_ = bc::raiseOrder(N_++) * control_points_;

--- a/src/polycurve.cpp
+++ b/src/polycurve.cpp
@@ -75,38 +75,38 @@ double PolyCurve::length(double t1, double t2) const
                                 [](double sum, const Curve& curve) { return sum + curve.length(); });
 }
 
-double PolyCurve::iterateByLength(double t, double s) const
+double PolyCurve::step(double t, double ds) const
 {
-  if (std::fabs(s) < bu::epsilon) // no-op
+  if (std::fabs(ds) < bu::epsilon) // no-op
     return t;
 
   double s_t = length(t);
 
-  if (s < -s_t + bu::epsilon) // out-of-scope
+  if (ds < -s_t + bu::epsilon) // out-of-scope
     return 0.0;
 
-  if (s > length() - s_t - bu::epsilon) // out-of-scope
+  if (ds > length() - s_t - bu::epsilon) // out-of-scope
     return size();
 
   unsigned idx = curveIdx(t);
   t -= idx;
 
-  s_t = s < 0 ? s_t - length(idx) : length(idx + 1) - s_t;
+  s_t = ds < 0 ? s_t - length(idx) : length(idx + 1) - s_t;
 
-  while (-s_t > s + bu::epsilon)
+  while (-s_t > ds + bu::epsilon)
   {
-    s += s_t;
+    ds += s_t;
     s_t = curves_[--idx].length();
     t = 1.0;
   }
-  while (s_t < s - bu::epsilon)
+  while (s_t < ds - bu::epsilon)
   {
-    s -= s_t;
+    ds -= s_t;
     s_t = curves_[++idx].length();
     t = 0.0;
   }
 
-  return idx + curves_[idx].iterateByLength(t, s);
+  return idx + curves_[idx].step(t, ds);
 }
 
 std::pair<Point, Point> PolyCurve::endPoints() const

--- a/src/polycurve.cpp
+++ b/src/polycurve.cpp
@@ -38,10 +38,15 @@ const std::deque<Curve>& PolyCurve::curves() const { return curves_; }
 
 PointVector PolyCurve::polyline() const
 {
-  double flatness = std::numeric_limits<double>::infinity();
-  for (const auto& curve : curves_)
-    flatness = std::min(flatness, curve.boundingBox().diagonal().norm() / 1000);
-  return polyline(flatness);
+  if (curves_.empty())
+    return {};
+  std::vector<Point> polyline = curves_[0].polyline();
+  for (unsigned k{1}; k < curves_.size(); k++)
+  {
+    polyline.pop_back();
+    polyline = bu::concatenate(std::move(polyline), curves_[k].polyline());
+  }
+  return polyline;
 }
 
 PointVector PolyCurve::polyline(double flatness) const
@@ -59,10 +64,14 @@ PointVector PolyCurve::polyline(double flatness) const
 
 ParamVector PolyCurve::polylineParams() const
 {
-  double flatness = std::numeric_limits<double>::infinity();
-  for (const auto& curve : curves_)
-    flatness = std::min(flatness, curve.boundingBox().diagonal().norm() / 1000);
-  return polylineParams(flatness);
+  ParamVector params;
+  for (unsigned k{}; k < curves_.size(); k++)
+  {
+    auto subcurve_params = curves_[k].polylineParams();
+    std::transform(subcurve_params.begin() + (k != 0), subcurve_params.end(), std::back_inserter(params),
+                   [k](double t) { return k + t; });
+  }
+  return params;
 }
 
 ParamVector PolyCurve::polylineParams(double flatness) const

--- a/src/polycurve.cpp
+++ b/src/polycurve.cpp
@@ -36,6 +36,14 @@ std::deque<Curve>& PolyCurve::curves() { return curves_; }
 
 const std::deque<Curve>& PolyCurve::curves() const { return curves_; }
 
+PointVector PolyCurve::polyline() const
+{
+  double flatness = std::numeric_limits<double>::infinity();
+  for (const auto& curve : curves_)
+    flatness = std::min(flatness, curve.boundingBox().diagonal().norm() / 1000);
+  return polyline(flatness);
+}
+
 PointVector PolyCurve::polyline(double flatness) const
 {
   if (curves_.empty())
@@ -47,6 +55,26 @@ PointVector PolyCurve::polyline(double flatness) const
     polyline = bu::concatenate(std::move(polyline), curves_[k].polyline(flatness));
   }
   return polyline;
+}
+
+ParamVector PolyCurve::polylineParams() const
+{
+  double flatness = std::numeric_limits<double>::infinity();
+  for (const auto& curve : curves_)
+    flatness = std::min(flatness, curve.boundingBox().diagonal().norm() / 1000);
+  return polylineParams(flatness);
+}
+
+ParamVector PolyCurve::polylineParams(double flatness) const
+{
+  ParamVector params;
+  for (unsigned k{}; k < curves_.size(); k++)
+  {
+    auto subcurve_params = curves_[k].polylineParams(flatness);
+    std::transform(subcurve_params.begin() + (k != 0), subcurve_params.end(), std::back_inserter(params),
+                   [k](double t) { return k + t; });
+  }
+  return params;
 }
 
 double PolyCurve::length() const { return length(0.0, size()); }


### PR DESCRIPTION
 - remove `munipulateCurvature`, close #38
 - rename `iterateByLength` -> `step`
 - rename `elevateOrder` -> `raiseOrder`
 - add auto deduced `flatness` overload for `polyline`, close #40
 - add method `polylineParams` to retrieve parameter `t` from polyline
 - add overload for `splitCurves` into multiple subcurves, close #44
 - improve `intersections`